### PR TITLE
Add silent option

### DIFF
--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "If set, do not make a PR"
     default: "false"
     required: false
+  silent:
+    description: "Set a placeholder in the changelog and don't publish the release."
+    required: false
+    type: boolean
   since:
     description: "Use PRs with activity since this date or git reference"
     required: false
@@ -55,6 +59,7 @@ runs:
         export RH_VERSION_SPEC=${{ inputs.version_spec }}
         export RH_POST_VERSION_SPEC=${{ inputs.post_version_spec }}
         export RH_DRY_RUN=${{ inputs.dry_run }}
+        export RH_SILENT=${{ inputs.silent }}
         export RH_SINCE=${{ inputs.since }}
         export RH_SINCE_LAST_STABLE=${{ inputs.since_last_stable }}
 

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -15,6 +15,10 @@ on:
       post_version_spec:
         description: "Post Version Specifier"
         required: false
+      silent:
+        description: "Set a placeholder in the changelog and don't publish the release."
+        required: false
+        type: boolean
       since:
         description: "Use PRs with activity since this date or git reference"
         required: false
@@ -41,6 +45,7 @@ jobs:
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           target: ${{ github.event.inputs.target }}
           branch: ${{ github.event.inputs.branch }}
+          silent: ${{ github.event.inputs.silent }}
           since: ${{ github.event.inputs.since }}
           since_last_stable: ${{ github.event.inputs.since_last_stable }}
 

--- a/example-workflows/full-release.yml
+++ b/example-workflows/full-release.yml
@@ -12,6 +12,10 @@ on:
       post_version_spec:
         description: "Post Version Specifier"
         required: false
+      silent:
+        description: "Set a placeholder in the changelog and don't publish the release."
+        required: false
+        type: boolean
       since:
         description: "Use PRs with activity since this date or git reference"
         required: false
@@ -40,6 +44,7 @@ jobs:
           version_spec: ${{ github.event.inputs.version_spec }}
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           branch: ${{ github.event.inputs.branch }}
+          silent: ${{ github.event.inputs.silent }}
           since: ${{ github.event.inputs.since }}
           since_last_stable: ${{ github.event.inputs.since_last_stable }}
 

--- a/example-workflows/prep-release.yml
+++ b/example-workflows/prep-release.yml
@@ -12,6 +12,10 @@ on:
       post_version_spec:
         description: "Post Version Specifier"
         required: false
+      silent:
+        description: "Set a placeholder in the changelog and don't publish the release."
+        required: false
+        type: boolean
       since:
         description: "Use PRs with activity since this date or git reference"
         required: false
@@ -33,6 +37,7 @@ jobs:
           version_spec: ${{ github.event.inputs.version_spec }}
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           branch: ${{ github.event.inputs.branch }}
+          silent: ${{ github.event.inputs.silent }}
           since: ${{ github.event.inputs.since }}
           since_last_stable: ${{ github.event.inputs.since_last_stable }}
 

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -249,6 +249,15 @@ changelog_path_options: t.Any = [
     ),
 ]
 
+silent_option: t.Any = [
+    click.option(
+        "--silent",
+        envvar="RH_SILENT",
+        default=False,
+        help="Set a placeholder in the changelog."
+    )
+]
+
 since_options: t.Any = [
     click.option(
         "--since",
@@ -268,6 +277,7 @@ changelog_options: t.Any = (
     branch_options
     + auth_options
     + changelog_path_options
+    + silent_option
     + since_options
     + [
         click.option(
@@ -383,7 +393,7 @@ def extract_changelog(dry_run, auth, changelog_path, release_url):
 @add_options(changelog_options)
 @use_checkout_dir()
 def build_changelog(
-    ref, branch, repo, auth, changelog_path, since, since_last_stable, resolve_backports
+    ref, branch, repo, auth, changelog_path, since, since_last_stable, resolve_backports, silent
 ):
     """Build changelog entry"""
     changelog.build_entry(
@@ -395,6 +405,7 @@ def build_changelog(
         since,
         since_last_stable,
         resolve_backports,
+        silent
     )
 
 
@@ -406,6 +417,7 @@ def build_changelog(
 @add_options(changelog_path_options)
 @add_options(dry_run_options)
 @add_options(post_version_spec_options)
+@add_options(silent_option)
 @use_checkout_dir()
 def draft_changelog(
     version_spec,
@@ -419,6 +431,7 @@ def draft_changelog(
     dry_run,
     post_version_spec,
     post_version_message,
+    silent
 ):
     """Create a changelog entry PR"""
     lib.draft_changelog(
@@ -433,6 +446,7 @@ def draft_changelog(
         dry_run,
         post_version_spec,
         post_version_message,
+        silent
     )
 
 
@@ -673,10 +687,11 @@ def publish_assets(
 @add_options(auth_options)
 @add_options(dry_run_options)
 @add_options(release_url_options)
+@add_options(silent_option)
 @use_checkout_dir()
-def publish_release(auth, dry_run, release_url):
+def publish_release(auth, dry_run, release_url, silent):
     """Publish GitHub release"""
-    lib.publish_release(auth, dry_run, release_url)
+    lib.publish_release(auth, dry_run, release_url, silent)
 
 
 @main.command()

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -57,6 +57,7 @@ def draft_changelog(
     dry_run,
     post_version_spec,
     post_version_message,
+    silent
 ):
     """Create a changelog entry PR"""
     repo = repo or util.get_repo()
@@ -103,6 +104,7 @@ def draft_changelog(
         "post_version_spec": post_version_spec,
         "post_version_message": post_version_message,
         "expected_sha": current_sha,
+        "silent": silent
     }
     with tempfile.TemporaryDirectory() as d:
         metadata_path = Path(d) / util.METADATA_JSON
@@ -410,7 +412,7 @@ def publish_assets(  # noqa
         util.log("No files to upload")
 
 
-def publish_release(auth, dry_run, release_url):
+def publish_release(auth, dry_run, release_url, silent):
     """Publish GitHub release"""
     util.log(f"Publishing {release_url}")
 
@@ -426,7 +428,7 @@ def publish_release(auth, dry_run, release_url):
         release.target_commitish,
         release.name,
         release.body,
-        False,
+        silent,  # In silent mode the release will stay in draft mode
         release.prerelease,
     )
 


### PR DESCRIPTION
This adds the ability to do a silent release; i.e. a release that will have a placeholder in the changelog and that will keep the release in draft mode.

- [x] Add silent option
- [ ] Add workflow to remove the placeholder (I would like to have it execute on [release published event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) to reduce maintenance burden)